### PR TITLE
Adding driver’s license and fixing the link in public transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 node_modules
 _book
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *.log
 node_modules
 _book
-.DS_Store

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -11,6 +11,7 @@ Pages that are not yet linked are ideas for pages if anyone wants to contribute.
 1. Shopping for furniture and electronics
 1. Grocery shopping
 1. [Getting a bank account](/pages/bank-account.md)
+1. [Driver’s license](/pages/drivers-license.md)
 1. Registering for tax
 1. Access to healthcare
 1. Schools for expats

--- a/en/pages/drivers-license.md
+++ b/en/pages/drivers-license.md
@@ -1,0 +1,15 @@
+# Driver’s license
+
+Permanent residents of Iceland must have an Icelandic driver’s license to drive. A license issued in the Faroe Islands or a country that is party to the EEA agreement is except from that rule.
+
+## Trading a foreign license
+
+Those living in Iceland can trade their foreign driver’s license for an Icelandic one.
+
+The office of the district magistrate will have the proper forms for doing so. You can reach it by emailing smh@syslumenn.is
+or calling +354 458 2000.
+
+An application must usually include:
+- A 35x45 mm photograph of the applicant.
+- The foreign driver’s license.
+- A statement of good health or a health certificate.

--- a/en/pages/drivers-license.md
+++ b/en/pages/drivers-license.md
@@ -1,13 +1,17 @@
 # Driver’s license
 
-Permanent residents of Iceland must have an Icelandic driver’s license to drive. A license issued in the Faroe Islands or a country that is party to the EEA agreement is except from that rule.
+Permanent residents of Iceland must have an Icelandic driver’s license to
+drive. A license issued in the Faroe Islands or a country that is party to the
+EEA agreement is except from that rule.
 
 ## Trading a foreign license
 
-Those living in Iceland can trade their foreign driver’s license for an Icelandic one.
+Those living in Iceland can trade their foreign driver’s license for an
+Icelandic one.
 
-The office of the district magistrate will have the proper forms for doing so. You can reach it by emailing smh@syslumenn.is
-or calling +354 458 2000.
+The office of the district magistrate will have the proper forms for doing so.
+You can reach it by emailing [smh@syslumenn.is](mailto:smh@syslumenn.is) or
+calling +354 458 2000.
 
 An application must usually include:
 - A 35x45 mm photograph of the applicant.

--- a/en/pages/public-transport.md
+++ b/en/pages/public-transport.md
@@ -1,5 +1,5 @@
 # Public transport
 
-[Strætó.is](https://www.straet.is)
+[Bus.is](https://www.bus.is)
 
 Strætó operates the public transport bus network across the capital area. The schedule and routing is accessible via Google Maps, Transit and Moovit. 


### PR DESCRIPTION
A short introductory page on a driver’s license for permanent residents and a fix to the public transport link which was broken. The new one points to the english version of the Strætó site.